### PR TITLE
Export convertNodeToReactElement from package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,5 +4,5 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
-import { convertHtmlToReact } from './convertHtmlToReact'
-export default convertHtmlToReact
+export { convertHtmlToReact as default } from './convertHtmlToReact'
+export { convertNodeToReactElement } from './convertNodeToReactElement'


### PR DESCRIPTION
### Description

This PR adds a re-export of `convertNodeToReactElement`.
Without this, it's hard to write a transform function that could defer to the default transform for e.g. child nodes à la

```
function transform(node: Element, index: number | string) {
  if (node.name === 'a') {
    return (
      <Link key={index} href={href}>
        {convertNodeToReactElement(node, index, htmlTransform)}
      </Link>
    );
  }
  return undefined;
}
```

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/html-to-react/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.

### Notes

This seems to be quite what #31 attempted to do.