### PR TITLE
Use official jest types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "author": "The HedgeDoc Authors",
   "license": "AGPL-3.0",
   "devDependencies": {
-    "@types/jest": "28.1.5",
+    "@jest/types": "28.1.3",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
     "@typescript-eslint/eslint-plugin": "5.30.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,7 +417,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@hedgedoc/html-to-react@workspace:."
   dependencies:
-    "@types/jest": 28.1.5
+    "@jest/types": 28.1.3
     "@types/react": 18.0.15
     "@types/react-dom": 18.0.6
     "@typescript-eslint/eslint-plugin": 5.30.6
@@ -694,7 +694,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/types@npm:^28.1.3":
+"@jest/types@npm:28.1.3, @jest/types@npm:^28.1.3":
   version: 28.1.3
   resolution: "@jest/types@npm:28.1.3"
   dependencies:
@@ -911,16 +911,6 @@ __metadata:
   dependencies:
     "@types/istanbul-lib-report": "*"
   checksum: f1ad54bc68f37f60b30c7915886b92f86b847033e597f9b34f2415acdbe5ed742fa559a0a40050d74cdba3b6a63c342cac1f3a64dba5b68b66a6941f4abd7903
-  languageName: node
-  linkType: hard
-
-"@types/jest@npm:28.1.5":
-  version: 28.1.5
-  resolution: "@types/jest@npm:28.1.5"
-  dependencies:
-    jest-matcher-utils: ^28.0.0
-    pretty-format: ^28.0.0
-  checksum: 994bfc25a5e767ec1506a2a7d94e60a7a5645b2e4e8444c56ae902f3a3e27ae54e821e41c1b4e7c8d7f5022bf5abfdd0460ead223ba6f2d0a194e5b2bed1ad76
   languageName: node
   linkType: hard
 
@@ -2850,7 +2840,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-matcher-utils@npm:^28.0.0, jest-matcher-utils@npm:^28.1.3":
+"jest-matcher-utils@npm:^28.1.3":
   version: 28.1.3
   resolution: "jest-matcher-utils@npm:28.1.3"
   dependencies:
@@ -3713,7 +3703,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pretty-format@npm:^28.0.0, pretty-format@npm:^28.1.3":
+"pretty-format@npm:^28.1.3":
   version: 28.1.3
   resolution: "pretty-format@npm:28.1.3"
   dependencies:


### PR DESCRIPTION
### Description
This PR swaps `@types/jest` with `jest/type` as it is the official type package.

### Steps

- [x] Added changes
- [x] I read the [contribution documentation](https://github.com/hedgedoc/markdown-it-better-task-lists/blob/main/CONTRIBUTING.md) and signed-off my commits to accept the DCO.
